### PR TITLE
add start_date & end_date columns to bookings table

### DIFF
--- a/db/migrate/20220801103309_bookings_add_start_date_and_end_date.rb
+++ b/db/migrate/20220801103309_bookings_add_start_date_and_end_date.rb
@@ -1,0 +1,6 @@
+class BookingsAddStartDateAndEndDate < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :bookings, :date, :start_date
+    add_column :bookings, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_30_223110) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_01_103309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,11 +27,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_30_223110) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.date "date"
+    t.date "start_date"
     t.bigint "user_id", null: false
     t.bigint "boat_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "end_date"
     t.index ["boat_id"], name: "index_bookings_on_boat_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
Renamed '**date**' -> '**start_date**' and added an '**end_date**' column in the bookings table. 
This should allow us to calculate booking length and as a result total cost.
Schema has changed.