### PR TITLE
Permit Name field to be saved in user registration and edit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  # allows the app to save the name in the user registration and editing pages
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:edit, keys: [:name])
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,7 @@
     <%= f.input :name,
                 required: true,
                 autofocus: true,
-                input_html: { autocomplete: "name"}%>
+                input_html: { autocomplete: "name" }%>
     <%= f.input :email,
                 required: true,
                 autofocus: true,


### PR DESCRIPTION
This fixes the error of 'Name field can't be empty' essentially persisting the data and allowing registration.