### PR TITLE
rename 'type' column in boats table due to Active Record errors

### DIFF
--- a/db/migrate/20220803153244_rename_type_from_boats.rb
+++ b/db/migrate/20220803153244_rename_type_from_boats.rb
@@ -1,0 +1,5 @@
+class RenameTypeFromBoats < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :boats, :type, :boat_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_01_213925) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_03_153244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "boats", force: :cascade do |t|
     t.string "name"
-    t.string "type"
+    t.string "boat_type"
     t.string "address"
     t.integer "price"
     t.text "description"


### PR DESCRIPTION
Trying to fix the error below. The word 'type' should not be used as a column in a table. 
 -  I have created a new migration file renaming the column to 'boat_type'

![image](https://user-images.githubusercontent.com/103219901/182651964-06b89b7d-690c-40c0-bc74-66a28e194c15.png)
