### PR TITLE
Add Active Storage and photos asociation in model

### DIFF
--- a/app/controllers/boats_controller.rb
+++ b/app/controllers/boats_controller.rb
@@ -39,7 +39,7 @@ class BoatsController < ApplicationController
   private
 
   def boat_params
-    params.require(:boat).permit(:name, :boat_type, :address, :price, :description)
+    params.require(:boat).permit(:name, :boat_type, :address, :price, :description, photos: [])
   end
 
   def set_boat

--- a/app/models/boat.rb
+++ b/app/models/boat.rb
@@ -1,5 +1,6 @@
 class Boat < ApplicationRecord
   # associations
+  has_many_attached :photos
   belongs_to :user
   has_many :bookings, dependent: :destroy
   has_many :reviews, dependent: :destroy

--- a/app/views/boats/new.html.erb
+++ b/app/views/boats/new.html.erb
@@ -9,6 +9,7 @@
           <%= f.input :address %>
           <%= f.input :description %>
           <%= f.input :price %>
+          <%= f.input :photos, as: :file, input_html: { multiple: true} %>
           <%= f.submit class: 'btn btn-primary' %>
         <% end %>
       </div>

--- a/app/views/boats/show.html.erb
+++ b/app/views/boats/show.html.erb
@@ -1,6 +1,10 @@
 <div>
 <h2> Book <%= @boat.name%> now!</h2>
 <div>
+<% @boat.photos.each do |photo| %>
+<%= cl_image_tag photo.key, height: 200, width: 300, crop: :fill %>
+<% end %>
+<div>
 <p><%= @boat.boat_type.capitalize %></p>
 <p><%= @boat.address %></p>
 <p><%= @boat.description %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,3 +1,6 @@
+cloudinary:
+  service: Cloudinary
+
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>

--- a/db/migrate/20220806003216_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220806003216_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_05_172744) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_06_003216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "boats", force: :cascade do |t|
     t.string "name"
@@ -61,6 +89,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_05_172744) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "boats", "users"
   add_foreign_key "bookings", "boats"
   add_foreign_key "bookings", "users"


### PR DESCRIPTION
To complement cloudinary service, with this configuration, users can now upload one or more photos during the product listing. 
Configuration valid for development environment for the time being. 