### PR TITLE
start boat index card grid view and minimal styling

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,0 +1,73 @@
+.cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 16px;
+}
+
+// Smallest device
+@media (min-width: 100px) and (max-width: 575px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Small devices (landscape phones, 576px and up)
+@media (min-width: 576px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+// Medium devices (tablets, 768px and up)
+@media (min-width: 768px) {
+  .cards {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+// Large devices (desktops, 992px and up)
+@media (min-width: 992px) {
+  .cards {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+// Extra large devices (large desktops, 1200px and up)
+@media (min-width: 1200px) {
+  .cards {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.card-boat {
+  overflow: hidden;
+  height: 120px;
+  background: white;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+}
+
+.card-boat img {
+  height: 100%;
+  width: 120px;
+  object-fit: cover;
+}
+
+.card-boat h2 {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.card-boat p {
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: .7;
+  margin-bottom: 0;
+  margin-top: 8px;
+}
+
+.card-boat .card-boat-infos {
+  padding: 16px;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,3 +3,4 @@
 @import "avatar";
 @import "form_legend_clear";
 @import "navbar";
+@import "card";

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -3,15 +3,10 @@
   font-size: 150px;
 }
 
-.logo {
-  border-radius: 1px solid red;
-  font-size: 15px;
-}
-
 p {
-  font-size: 15px;
+  font-size: 16px;
 }
 
 h1 {
-  font-size: 25px;
+  color: #06283D;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,5 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "bootstrap"
+// this is a test - make sure you inspect and check the console
+console.log("Hello world")

--- a/app/views/boats/index.html.erb
+++ b/app/views/boats/index.html.erb
@@ -1,13 +1,15 @@
 <h1>Boats</h1>
-  <div class= "row text-center p-3">
+  <div class= "cards">
   <% @boats.each do |boat| %>
   <%= link_to boat do %>
-    <div class= "card">
+    <div class= "card-boat">
+      <div class="card-boat-infos">
         <p><%= boat.name %></p>
         <p><%= boat.address %></p>
         <p><%= boat.boat_type %></p>
-        <p><%= boat.price %></p>
-        <p>⭐<%= boat.average_rating %></p>
+        <p><strong>£<%= boat.price %>.00/day</strong></p>
+        <p>⭐<%=boat.average_rating %></p>
+      </div>
     </div>
     <br>
 <% end %>


### PR DESCRIPTION
- Started the grid layout for Boat index page and a scaffold of the scss.
 - tweaks to index boat page to show price in £ and per/day basis.
- Removed some css lines in the _home.scss file @mohednazari  - now we can work on scss
- Added a test console log in javascript app. Please test by running the rails server in one terminal and yarn build --watch in another -> then inspect page in browser and check console
