### PR TITLE
hide links in views according to pundit rules

### DIFF
--- a/app/controllers/boats_controller.rb
+++ b/app/controllers/boats_controller.rb
@@ -1,4 +1,5 @@
 class BoatsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:index, :show]
   before_action :set_boat, only: [:show, :destroy, :edit, :update]
 
   def index

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:home]
   def home
     @boats = Boat.all
   end

--- a/app/views/boats/show.html.erb
+++ b/app/views/boats/show.html.erb
@@ -12,22 +12,33 @@
 <p>⭐<%= @boat.average_rating %></p>
 </div>
 <div>
-<%# This link should only be visible to Customers %>
+
 <%= render "reviews" %>
+<%# An owner of a boat can't book his own boat %>
+<% unless policy(@boat).edit? %>
 <%= link_to "Book this boat", new_boat_booking_path(@boat) %>
+<% end %>
 <br>
 <%= link_to 'Choose another',
   boats_path
 %>
 <br>
+<%# An owner of a boat can't review his own boat %>
+<% unless policy(@boat).edit? %>
 <%= link_to "Review this boat", new_boat_review_path(@boat) %>
+<% end %>
 <br>
-<%# Delete should only be visible to Owner %>
+<%# Edit only visible to Owner if true %>
+<% if policy(@boat).edit? %>
 <%= link_to 'Edit this listing', edit_boat_path%>
+<% end %>
 <br>
+<%# Delete only visible to Owner if true %>
+<% if policy(@boat).destroy? %>
 <%= link_to 'Delete',
   boat_path(@boat),
   data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}
 %>
+<% end %>
 <br>
 </div>


### PR DESCRIPTION
- non authenticated users can see: home, index (boat) and show(boat)
- add code to reflect pundit authorizatin rules in show view as follows:
- a boat owner can't delete someone else's listing
- a boat owner can't edit someone else's listing
- a boat owner can't review his own listing
- a boat owner can't book his own boat

- next step - add pundit to reviews and bookings
